### PR TITLE
Fix "Invalid argument" error when sending (not replying) comments

### DIFF
--- a/router/index.js
+++ b/router/index.js
@@ -68,7 +68,9 @@ router.post('/api/createComment', async function (ctx) {
   const {message, thread, author_name, author_email, parent} = body
   const params = new URLSearchParams()
   params.append('api_key', api_key)
-  params.append('parent', parent)
+  if (parent !== undefined) {
+    params.append('parent', parent)
+  }
   params.append('message', message)
   params.append('thread', thread)
   params.append('author_name', author_name)


### PR DESCRIPTION
One cannot send comments directly (instead of replying others'), with the error message of
```
发表失败
Invalid argument, 'parent': post must be an integer, was 'undefined'
```

This pr fixes it by neglecting the cases where `parent` is undefined, which will then be `null` by default as per the [Disqus API doc](https://disqus.com/api/docs/posts/create/).